### PR TITLE
fix(infinity-rooms): make the troubleshooting guide reachable

### DIFF
--- a/pages/infinity-rooms/script.ts
+++ b/pages/infinity-rooms/script.ts
@@ -51,7 +51,11 @@ function initialize(): void {
   root.appendChild(createStatusCardsContainer([promptAPIStatusPanel.element, webGPUStatusPanel.element]));
 
   // 스테이지: 캔버스가 주인공인 방 카드와 미니맵 HUD 패널을 한 그리드로 묶습니다.
-  const roomCard = createRoomCard();
+  // 경고 카드의 '해결 방법 보기'는 미지원 상태 카드를 화면에 띄우고 해결 가이드 툴팁을 직접 엽니다.
+  const roomCard = createRoomCard({
+    onResolvePromptAPI: () => promptAPIStatusPanel.openTroubleshooting(),
+    onResolveWebGPU: () => webGPUStatusPanel.openTroubleshooting(),
+  });
   const stage = document.createElement('section');
   stage.className = 'stage';
   stage.setAttribute('aria-label', '3D 방 탐험');

--- a/pages/infinity-rooms/scripts/interfaces/room-card.ts
+++ b/pages/infinity-rooms/scripts/interfaces/room-card.ts
@@ -99,6 +99,13 @@ export interface RoomCard {
   destroy(): void;
 }
 
+export interface RoomCardOptions {
+  // 경고 카드의 '해결 방법 보기'가 호출할, 미지원 상태 카드의 가이드 열기 콜백들입니다.
+  // 미지원 분기(Prompt API / WebGPU)에 맞는 카드를 화면에 띄우고 해결 가이드를 엽니다.
+  onResolvePromptAPI?: () => void;
+  onResolveWebGPU?: () => void;
+}
+
 // 캔버스 좌하단에 띄우는 테마 칩(라벨 + 테마명)을 만듭니다.
 function createThemeChip(): { element: HTMLDivElement; nameElement: HTMLSpanElement } {
   const chip = document.createElement('div');
@@ -379,7 +386,9 @@ function createDetailPanel(): {
   };
 }
 
-export function createRoomCard(): RoomCard {
+export function createRoomCard(options: RoomCardOptions = {}): RoomCard {
+  const { onResolvePromptAPI, onResolveWebGPU } = options;
+
   const card = document.createElement('div');
   card.className = 'new-card';
 
@@ -669,7 +678,7 @@ export function createRoomCard(): RoomCard {
   };
   document.addEventListener('fullscreenchange', handleFullscreenChange);
 
-  const showWarning = (titleText: string, descriptionText: string) => {
+  const showWarning = (titleText: string, descriptionText: string, onResolution?: () => void) => {
     // 가용성 상실로 인한 경고는 장면을 정지(stop)만 해 자원을 보존하고, 재가용 시 재개할 수 있게 둡니다.
     // 시작 실패(hasStartFailed) 경고는 장면이 손상된 상태이므로 호출부에서 별도로 dispose 합니다.
     if (sceneState.handle && !sceneState.hasStartFailed) {
@@ -681,7 +690,7 @@ export function createRoomCard(): RoomCard {
 
     // 이전 경고 본문이 있으면 제거하고 새 본문으로 교체합니다.
     card.querySelector('.warning-card-content')?.remove();
-    card.appendChild(buildWarningCardContent({ titleText, descriptionText, hasResolutionAction: true }));
+    card.appendChild(buildWarningCardContent({ titleText, descriptionText, hasResolutionAction: true, onResolution }));
   };
 
   // 장면 시작(또는 재개)을 수행합니다. 이미 동작 중이면 무시하고, 정지(stop)된 상태면 재개합니다.
@@ -761,15 +770,15 @@ export function createRoomCard(): RoomCard {
     const { isPromptAPIAvailable, isWebGPUAvailable } = availability;
 
     if (isPromptAPIAvailable === false && isWebGPUAvailable === false) {
-      showWarning('3D 공간을 시작할 수 없습니다', 'Prompt API와 WebGPU 모두 사용 불가 상태입니다. 설정을 활성화해 주세요.');
+      showWarning('3D 공간을 시작할 수 없습니다', 'Prompt API와 WebGPU 모두 사용 불가 상태입니다. 설정을 활성화해 주세요.', onResolvePromptAPI);
       return;
     }
     if (isPromptAPIAvailable === false) {
-      showWarning('3D 공간을 시작할 수 없습니다', 'Prompt API가 활성화되지 않아 WebGPU 3D 공간을 구동할 수 없습니다. 크롬 Built-in AI 설정을 확인해 주세요.');
+      showWarning('3D 공간을 시작할 수 없습니다', 'Prompt API가 활성화되지 않아 WebGPU 3D 공간을 구동할 수 없습니다. 크롬 Built-in AI 설정을 확인해 주세요.', onResolvePromptAPI);
       return;
     }
     if (isWebGPUAvailable === false) {
-      showWarning('3D 공간을 시작할 수 없습니다', '이 기기/브라우저에서 WebGPU가 지원되지 않습니다. 하드웨어 가속 설정을 확인해 주세요.');
+      showWarning('3D 공간을 시작할 수 없습니다', '이 기기/브라우저에서 WebGPU가 지원되지 않습니다. 하드웨어 가속 설정을 확인해 주세요.', onResolveWebGPU);
       return;
     }
 

--- a/pages/infinity-rooms/scripts/interfaces/status-panels.ts
+++ b/pages/infinity-rooms/scripts/interfaces/status-panels.ts
@@ -36,6 +36,8 @@ export interface StatusPanelOptions<Status extends string> {
 export interface StatusPanel<Status extends string> {
   element: HTMLElement;
   onStatusChange(callback: (status: Status) => void): void;
+  // 카드를 화면 안으로 스크롤하고 해결 가이드 툴팁을 엽니다. 경고 카드의 '해결 방법 보기'가 호출합니다.
+  openTroubleshooting(): void;
 }
 
 // 진단 진행 상태 머신입니다. diagnose 의 rejection 도 failed 상태로 수렴합니다.
@@ -158,6 +160,11 @@ export function createStatusPanel<Status extends string>(options: StatusPanelOpt
       if (state.phase === 'diagnosed') {
         callback(state.status);
       }
+    },
+    openTroubleshooting() {
+      const prefersReducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+      panel.scrollIntoView({ behavior: prefersReducedMotion ? 'auto' : 'smooth', block: 'start' });
+      statusTooltip.open();
     },
   };
 }

--- a/pages/infinity-rooms/scripts/interfaces/tooltips.ts
+++ b/pages/infinity-rooms/scripts/interfaces/tooltips.ts
@@ -76,16 +76,6 @@ export function transitionTooltip(state: TooltipStateMachineState, event: Toolti
   }
 }
 
-// Popover API 미지원 환경을 대비한 구조적 타입 가드입니다.
-interface PopoverElement {
-  showPopover(): void;
-  hidePopover(): void;
-}
-
-function isPopoverElement(element: unknown): element is PopoverElement {
-  return typeof element === 'object' && element !== null && 'showPopover' in element && 'hidePopover' in element;
-}
-
 // 상태 톤입니다. 툴팁 제목(도트 + 텍스트)의 색을 결정합니다.
 export type StatusTone = 'ready' | 'pending' | 'error';
 
@@ -135,6 +125,28 @@ export function createStatusTooltip(options: { tooltipElementId: string; pillEle
     }
   };
 
+  // Popover API(top layer) 지원 여부를 한 번만 판정합니다.
+  // 미지원 브라우저(예: 구형/타 브라우저)에서는 showPopover 가 없어 툴팁이 영영 보이지 않으므로,
+  // 카드 안 일반 흐름 블록으로 펼치는 폴백(.is-open-fallback)으로 같은 가이드를 노출합니다.
+  const supportsPopover = typeof tooltipElement.showPopover === 'function' && typeof tooltipElement.hidePopover === 'function';
+
+  const showTooltip = () => {
+    if (supportsPopover) {
+      tooltipElement.showPopover();
+      positionTooltip();
+    } else {
+      tooltipElement.classList.add('is-open-fallback');
+    }
+  };
+
+  const hideTooltip = () => {
+    if (supportsPopover) {
+      tooltipElement.hidePopover();
+    } else {
+      tooltipElement.classList.remove('is-open-fallback');
+    }
+  };
+
   store.subscribe((previousState, nextState) => {
     if (previousState.visibility === nextState.visibility) {
       return;
@@ -143,27 +155,19 @@ export function createStatusTooltip(options: { tooltipElementId: string; pillEle
     try {
       if (nextState.visibility === 'closed') {
         tooltipElement.style.pointerEvents = '';
-        if (isPopoverElement(tooltipElement)) {
-          tooltipElement.hidePopover();
-        }
+        hideTooltip();
         document.removeEventListener('click', handleOutsideClick);
       } else if (nextState.visibility === 'hovered') {
         tooltipElement.style.pointerEvents = 'none';
-        if (isPopoverElement(tooltipElement)) {
-          tooltipElement.showPopover();
-        }
-        positionTooltip();
+        showTooltip();
       } else {
         tooltipElement.style.pointerEvents = 'auto';
-        if (isPopoverElement(tooltipElement)) {
-          tooltipElement.showPopover();
-        }
-        positionTooltip();
+        showTooltip();
         tooltipElement.focus();
         document.addEventListener('click', handleOutsideClick);
       }
     } catch (error) {
-      console.error('툴팁 popover 제어에 실패했습니다:', error);
+      console.error('툴팁 표시 제어에 실패했습니다:', error);
     }
   });
 

--- a/pages/infinity-rooms/scripts/interfaces/tooltips.ts
+++ b/pages/infinity-rooms/scripts/interfaces/tooltips.ts
@@ -15,6 +15,7 @@ export type TooltipStateMachineEvent =
   | { type: 'MOUSE_ENTER' }
   | { type: 'MOUSE_LEAVE' }
   | { type: 'CLICK' }
+  | { type: 'OPEN' }
   | { type: 'OUTSIDE_CLICK' };
 
 export const initialTooltipStateMachineState: TooltipStateMachineState = {
@@ -56,6 +57,16 @@ export function transitionTooltip(state: TooltipStateMachineState, event: Toolti
       }
       return { ...state, visibility: 'pinned' };
     }
+    case 'OPEN': {
+      // 외부(경고 카드의 '해결 방법 보기')에서 호출하는 멱등 열기입니다. 토글하지 않고 항상 pinned 로 수렴합니다.
+      if (!state.isContentReady) {
+        return state;
+      }
+      if (state.visibility === 'pinned') {
+        return state;
+      }
+      return { ...state, visibility: 'pinned' };
+    }
     case 'OUTSIDE_CLICK': {
       if (state.visibility === 'pinned') {
         return { ...state, visibility: 'closed' };
@@ -82,6 +93,8 @@ export interface StatusTooltip {
   element: HTMLDivElement;
   // 콘텐츠를 교체하고 툴팁을 열 수 있는 상태로 표시합니다.
   setContent(titleText: string, contentNode: Node, rawMessage: string, tone: StatusTone): void;
+  // 콘텐츠가 준비되어 있으면 툴팁을 pinned 로 엽니다(이미 열려 있으면 무시). 외부 진입점에서 사용합니다.
+  open(): void;
 }
 
 export function createStatusTooltip(options: { tooltipElementId: string; pillElement: HTMLElement }): StatusTooltip {
@@ -166,6 +179,9 @@ export function createStatusTooltip(options: { tooltipElementId: string; pillEle
     setContent(titleText, contentNode, rawMessage, tone) {
       tooltipElement.replaceChildren(buildTooltipFragment(titleText, contentNode, rawMessage, tone));
       store.dispatch({ type: 'CONTENT_READY' });
+    },
+    open() {
+      store.dispatch({ type: 'OPEN' });
     },
   };
 }

--- a/pages/infinity-rooms/scripts/interfaces/warning-card.ts
+++ b/pages/infinity-rooms/scripts/interfaces/warning-card.ts
@@ -6,6 +6,8 @@ export interface WarningCardContentOptions {
   descriptionText: string;
   // true 이면 상단 상태 카드로 안내하는 '해결 방법 보기' 버튼과 힌트를 보여줍니다.
   hasResolutionAction: boolean;
+  // 제공되면 '해결 방법 보기' 클릭 시 단순 스크롤 대신 이 콜백(미지원 상태 카드의 가이드 열기)을 실행합니다.
+  onResolution?: () => void;
 }
 
 // 상태 카드 스트립으로 부드럽게 스크롤합니다. 모션 감소 환경에서는 즉시 이동합니다.
@@ -19,7 +21,7 @@ function scrollToStatusCards(): void {
 }
 
 export function buildWarningCardContent(options: WarningCardContentOptions): HTMLDivElement {
-  const { titleText, descriptionText, hasResolutionAction } = options;
+  const { titleText, descriptionText, hasResolutionAction, onResolution } = options;
 
   const content = document.createElement('div');
   content.className = 'warning-card-content';
@@ -51,12 +53,18 @@ export function buildWarningCardContent(options: WarningCardContentOptions): HTM
     resolutionButton.type = 'button';
     resolutionButton.className = 'button-ai';
     resolutionButton.textContent = '해결 방법 보기';
-    resolutionButton.addEventListener('click', scrollToStatusCards);
+    // stopPropagation: 가이드 열기 직후 등록되는 바깥 클릭 닫기 핸들러에 이 클릭이 닿아 즉시 닫히는 것을 막습니다.
+    resolutionButton.addEventListener('click', (event) => {
+      event.stopPropagation();
+      (onResolution ?? scrollToStatusCards)();
+    });
     actions.appendChild(resolutionButton);
 
     const hint = document.createElement('span');
     hint.className = 'warning-hint';
-    hint.textContent = '상단 상태 카드의 배지를 누르면 자세한 해결 가이드가 열립니다.';
+    hint.textContent = onResolution
+      ? "'해결 방법 보기'를 누르면 해당 상태 카드의 가이드가 열립니다. (배지를 직접 눌러도 됩니다)"
+      : '상단 상태 카드의 배지를 누르면 자세한 해결 가이드가 열립니다.';
     actions.appendChild(hint);
 
     body.appendChild(actions);

--- a/pages/infinity-rooms/styles/_tooltip.scss
+++ b/pages/infinity-rooms/styles/_tooltip.scss
@@ -279,3 +279,24 @@
     transition: none;
   }
 }
+
+// ----------------------------------------------------------------------------
+// Popover API 미지원 폴백 — top layer(showPopover) 대신 카드 안 일반 흐름 블록으로
+// 가이드를 펼칩니다. JS(tooltips.ts)가 .is-open-fallback 을 토글합니다.
+// 위치 계산/화살표 없이 항상 보이게 해, 구형·타 브라우저에서도 해결 가이드를 노출합니다.
+// ----------------------------------------------------------------------------
+.status-tooltip.is-open-fallback {
+  position: static;
+  display: block;
+  opacity: 1;
+  transform: none;
+  width: auto;
+  max-width: 100%;
+  margin-top: vars.$spacing-3;
+  pointer-events: auto;
+
+  // 일반 흐름 배치라 알약을 가리키는 화살표는 의미가 없어 숨깁니다.
+  &::before {
+    display: none;
+  }
+}


### PR DESCRIPTION
## 개요

Prompt API·WebGPU **미지원 시 표시되는 해결 가이드**가 정작 열리지 않던 접근성 버그 2건을 고칩니다. 둘 다 "가이드에 도달하지 못하는" 문제입니다.

---

## 1. '해결 방법 보기' 버튼이 가이드를 열지 않음 (`50dbf18`)

- **증상**: 경고 카드의 **"해결 방법 보기"** 를 눌러도 아무 반응이 없음.
- **원인**: 버튼이 `#status-cards-container`로 **스크롤만** 하는데, 상태 카드가 이미 화면에 보이고 페이지가 스크롤 불가일 때 시각적 변화가 0이고, 가이드(popover)도 열지 않음.
- **수정**: 버튼이 **미지원 상태 카드의 가이드 popover를 직접 열도록** 배선(DI).
  - `tooltips.ts`: 멱등 `OPEN` 이벤트 + `StatusTooltip.open()`
  - `status-panels.ts`: `StatusPanel.openTroubleshooting()` (카드 스크롤 + 가이드 열기)
  - `warning-card.ts`: `onResolution` 콜백 + `stopPropagation`(열린 직후 바깥 클릭 닫기 핸들러에 의한 즉시 닫힘 방지) + 힌트 문구 갱신
  - `room-card.ts`/`script.ts`: 미지원 분기별로 알맞은 카드(Prompt API / WebGPU) 열기 콜백 연결

## 2. Popover API 미지원 브라우저에서 가이드가 보이지 않음 (`2b0af96`)

- **증상**: `showPopover`가 없는 구형·타 브라우저(Chrome <114·Safari <17·Firefox <125)에서는 배지·버튼 모두 가이드가 **에러도 없이** 열리지 않음.
- **원인**: 가이드 표시가 전적으로 Popover API(`:popover-open`)에 의존. 정작 가이드가 가장 필요한 구형 브라우저에서 안내가 닫혀 있던 셈.
- **수정**: `supportsPopover` 한 값으로 분기. 미지원이면 `.is-open-fallback` 클래스로 **카드 안 일반 흐름 블록**으로 가이드를 펼침.
  - `tooltips.ts`: show/hide 분기, 더 이상 쓰지 않는 `isPopoverElement` 가드/인터페이스 제거
  - `_tooltip.scss`: `.status-tooltip.is-open-fallback`(position:static, opacity:1, 화살표 숨김)

> native popover 경로는 기존과 동일(`showPopover` + 위치 계산)하여 변화 없음.

---

## 검증

- `tsc --noEmit` 0, `vitest run` 62/62, 배포 빌드 성공
- 실제 브라우저(chrome-devtools)에서 **실제 포인터 클릭**으로 확인:
  - native popover 환경: 버튼 클릭 → Prompt API "인터페이스 미지원" 가이드(`chrome://flags/...` 링크) 열림·유지
  - no-Popover 시뮬레이션(showPopover 제거): 가이드가 카드 안 인라인으로 표시됨
  - 코드 분기만 강제(`supportsPopover=false`)해도 native popover 유지 상태에서 fallback 진입 확인

## 참고

- base(`d82ea6a`)는 커밋 메시지 scope를 정리한 reword 히스토리이며, 이 PR은 **fix 2개만** 포함합니다.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
